### PR TITLE
fixed custom color attributes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,13 +14,12 @@
 
 <body>
 	<h2> TreeMap Default</h2>
-	<p>Default behavior is theme=light, community=true, primaryColor="#68b030", locale="en", circleBGColor="#23519b" </p>
+	<p>Default behavior is theme=light, community=true, primarycolor="#68b030", locale="en", circlebgcolor="#23519b" </p>
 	<tree-map user='salesforce'> </tree-map>
 
 	<h2> TreeMap for Partners</h2>
-	<p>Default behavior is theme=light, community=true, primaryColor="#68b030", locale="en", circleBGColor="#23519b" </p>
+	<p>Default behavior is theme=light, community=true, primarycolor="#68b030", locale="en", circlebgcolor="#23519b" </p>
 	<tree-map user='prf_h6smcMDN23Qet1CP7BEplM60'></tree-map>
-
 
 	<h2> TreeMap Variant 3</h2>
 	<p> Partner, theme="dark", community="false", locale="de" </p>
@@ -35,8 +34,8 @@
 	<tree-profile user='prf_h6smcMDN23Qet1CP7BEplM60'></tree-profile>
 
 	<h2> Tree Counter Variant 2</h2>
-	<p> Dark mode, locale="de" and community=false</p>
-	<tree-profile user='prf_h6smcMDN23Qet1CP7BEplM60' theme="dark" community="false" locale="de"></tree-profile>
+	<p> Dark mode, locale="de" and community=false, primarycolor="#007a49", locale="de", circlebgcolor="#000000"</p>
+	<tree-profile user='prf_h6smcMDN23Qet1CP7BEplM60' theme="dark" community="false" primarycolor="#007a49" locale="de" circlebgcolor="#000000"></tree-profile>
 </body>
 
 </html>

--- a/src/TreeMap/App.svelte
+++ b/src/TreeMap/App.svelte
@@ -12,14 +12,15 @@
 
     // Props that can be passed
     export let user;
-    export let primaryColor = "#68b030";
+    export let primarycolor = "#68b030";
+    export let circlebgcolor;
     export let theme = "light";
-    export let circleBGColor;
     export let community = "true";
     export let locale = "en";
-
-    let counterBGColor = circleBGColor
-        ? circleBGColor
+    
+    let primaryColor = primarycolor;
+    let counterBGColor = circlebgcolor
+        ? circlebgcolor
         : theme === "light"
         ? "#23519b"
         : "#2f3336";

--- a/src/TreeProfile/App.svelte
+++ b/src/TreeProfile/App.svelte
@@ -9,14 +9,15 @@
 
     // Props that can be passed
     export let user;
-    export let primaryColor = "#68b030";
-    export let circleBGColor;
+    export let primarycolor = "#68b030";
+    export let circlebgcolor;
     export let theme = "light";
     export let community = "true";
     export let locale = "en";
 
-    let counterBGColor = circleBGColor
-        ? circleBGColor
+    let primaryColor = primarycolor;
+    let counterBGColor = circlebgcolor
+        ? circlebgcolor
         : theme === "light"
         ? "#23519b"
         : "#2f3336";


### PR DESCRIPTION
Fixes # (no issue given, only reported in Slack)

Changes in this pull request:
- fixed the fact that properties of tags can not use upper case characters
- I kept the same names, so wrongly written HTML tags will still work 
- I already adapted the documentation at https://www.notion.so/Plant-for-the-Planet-Widgets-6d1b03d461334febb260fbe5574a4a23 as the former values have not worked anyway.