### PR TITLE
enabled German translations for showing large number abbreviations & removed abbreviation for thousands

### DIFF
--- a/utils/formatNumber.js
+++ b/utils/formatNumber.js
@@ -5,13 +5,12 @@ export function getFormattedNumber(
     const formatter = new Intl.NumberFormat(locale);
     return formatter.format(number);
   }
-  
-  // change 'de-disabled' to 'de' if you want to enable custom abbreviations for German
+
 const localizedAbbr = {
   'en': {
     'b': 'b', 'm': 'm', 'k': 'k',
   },
-  'de-disabled': {
+  'de': {
     'b': 'Mrd.', 'm': 'Mio.', 'k': 'Tsd.',
   },
 };
@@ -20,33 +19,33 @@ function getLocalizedAbbreviation(langCode, abbr) {
   return localizedAbbr[langCode] ? localizedAbbr[langCode][abbr] : localizedAbbr['en'][abbr];
 }
 
-  export function getFormattedRoundedNumber(
-    langCode,
-    number,
-    fractionDigits,
-  ) {
-    // console.log("getFormattedRoundedNumber", langCode, number, fractionDigits);
-    if (Math.round(number) === Math.round(number*fractionDigits*10)/(fractionDigits*10)) 
-      fractionDigits = 0;
-    const formatter = new Intl.NumberFormat(langCode, {
-      // These options are needed to round to whole numbers if that's what you want.
-      minimumFractionDigits: fractionDigits,
-      maximumFractionDigits: fractionDigits,
-    });
-    return formatter.format(number);
-  }
+export function getFormattedRoundedNumber(
+  langCode,
+  number,
+  fractionDigits,
+) {
+  // console.log("getFormattedRoundedNumber", langCode, number, fractionDigits);
+  if (Math.round(number) === Math.round(number*fractionDigits*10)/(fractionDigits*10))
+    fractionDigits = 0;
+  const formatter = new Intl.NumberFormat(langCode, {
+    // These options are needed to round to whole numbers if that's what you want.
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+  return formatter.format(number);
+}
 
-  export function localizedAbbreviatedNumber(
-    langCode,
-    number,
-    fractionDigits,
-  ) {
-    if (number >= 1000000000)
-      return getFormattedRoundedNumber(langCode, number/1000000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'b');
-    if (number >= 1000000)
-      return getFormattedRoundedNumber(langCode, number/1000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'm');
-    if (number >= 1000)
-      return getFormattedRoundedNumber(langCode, number/1000, fractionDigits) + getLocalizedAbbreviation(langCode, 'k');
-  
-    return getFormattedRoundedNumber(langCode, number, fractionDigits);
-  }
+export function localizedAbbreviatedNumber(
+  langCode,
+  number,
+  fractionDigits,
+) {
+  if (number >= 1000000000)
+    return getFormattedRoundedNumber(langCode, number/1000000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'b');
+  if (number >= 1000000)
+    return getFormattedRoundedNumber(langCode, number/1000000, fractionDigits) + getLocalizedAbbreviation(langCode, 'm');
+  //if (number >= 1000)
+  //  return getFormattedRoundedNumber(langCode, number/1000, fractionDigits) + getLocalizedAbbreviation(langCode, 'k');
+
+  return getFormattedRoundedNumber(langCode, number, fractionDigits);
+}


### PR DESCRIPTION
Same as https://github.com/Plant-for-the-Planet-org/planet-webapp/pull/951

Changes in this pull request:
- enabled German translations for showing large number abbreviations 

<img width="430" alt="Bildschirmfoto 2021-03-31 um 15 56 07" src="https://user-images.githubusercontent.com/1532418/113155759-ab51fb80-9239-11eb-8064-034797082dee.png">

- removed abbreviation for thousands

<img width="422" alt="Bildschirmfoto 2021-03-31 um 16 00 32" src="https://user-images.githubusercontent.com/1532418/113156910-b5c0c500-923a-11eb-96f3-9a8227a4ee9e.png">

