### PR TITLE
TreeProfile same class bug

### DIFF
--- a/src/TreeProfile/App.svelte
+++ b/src/TreeProfile/App.svelte
@@ -67,7 +67,7 @@
 </script>
 
 <div
-  class="treecounter"
+  class="treeProfile"
   style="--primary-color: {primarycolor};
     --counter-background-color: {counterbgcolor};
     --background-color: {theme ===
@@ -250,7 +250,7 @@
     all: initial;
   }
 
-  .treecounter {
+  .treeProfile {
     width: 100%;
     max-width: 420px;
     border-radius: 10px;


### PR DESCRIPTION
Adding tree profile widget script to html page produces this:


![image](https://user-images.githubusercontent.com/36331310/120633106-617ad100-c487-11eb-8a56-63a3c2e5b753.png)
