### PR TITLE
Remove min-height from tenant treecounter widget

### DIFF
--- a/src/TreeTenantCounter/App.svelte
+++ b/src/TreeTenantCounter/App.svelte
@@ -169,7 +169,7 @@
   }
 
   .treeCounterContainer {
-    min-height: 420px;
+/*     min-height: 420px; */
     width: 100%;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
with min-height
![image](https://user-images.githubusercontent.com/27153515/122869198-8c9b6680-d349-11eb-8389-cebe79037c55.png)

after removing min-height
![image](https://user-images.githubusercontent.com/27153515/122869264-a472ea80-d349-11eb-831a-53a00039e4cd.png)
