### PR TITLE
added distinction for singular and plural of trees for leaderboard widget

### DIFF
--- a/public/data/locales/cs.json
+++ b/public/data/locales/cs.json
@@ -10,6 +10,7 @@
   "forestfrontrunners": "Přední Stromvedoucí",
   "mostrecent": "NEJNOVĚJŠÍ",
   "mosttrees": "NEJVÍC STROMŮ",
+  "tree": "strom",
   "trees": "stromů",
   "the": "Počítáme, jak",
   "forestGrows": "roste."

--- a/public/data/locales/de.json
+++ b/public/data/locales/de.json
@@ -10,6 +10,7 @@
   "forestfrontrunners": "Baum-Bestenliste",
   "mostrecent": "NEUESTE SPENDEN",
   "mosttrees": "DIE MEISTEN BÄUME",
+  "tree": "Baum",
   "trees": "Bäume",
   "the": "Der",
   "forestGrows": "Wald wächst."

--- a/public/data/locales/en.json
+++ b/public/data/locales/en.json
@@ -10,6 +10,7 @@
   "forestfrontrunners": "Forest Frontrunners",
   "mostrecent": "MOST RECENT",
   "mosttrees": "MOST TREES",
+  "tree": "Tree",
   "trees": "Trees",
   "the": "The",
   "forestGrows": "Forest Grows."

--- a/public/data/locales/es.json
+++ b/public/data/locales/es.json
@@ -10,6 +10,7 @@
   "forestfrontrunners": "Fronteras del bosque",
   "mostrecent": "MÁS RECIENTES",
   "mosttrees": "LA MAYORÍA DE LOS ÁRBOLES",
+  "tree": "Árbol",
   "trees": "Árboles",
   "the": "El",
   "forestGrows": "El bosque crece."

--- a/public/data/locales/fr.json
+++ b/public/data/locales/fr.json
@@ -10,6 +10,7 @@
   "forestfrontrunners": "Les pionniers de la forêt",
   "mostrecent": "LE PLUS RÉCENT",
   "mosttrees": "LA PLUPART DES ARBRES",
+  "tree": "Arbre",
   "trees": "Arbres",
   "the": "Le",
   "forestGrows": "La forêt grandit."

--- a/public/data/locales/it.json
+++ b/public/data/locales/it.json
@@ -10,6 +10,7 @@
   "forestfrontrunners": "Frontisti della foresta",
   "mostrecent": "PIÙ RECENTI",
   "mosttrees": "PIÙ ALBERI",
+  "tree": "Albero",
   "trees": "Alberi",
   "the": "Il sito",
   "forestGrows": "La foresta cresce."

--- a/public/data/locales/pt-BR.json
+++ b/public/data/locales/pt-BR.json
@@ -10,6 +10,7 @@
   "forestfrontrunners": "Pioneiros Florestais",
   "mostrecent": "MAIS RECENTES",
   "mosttrees": "MAIS ÁRVORES",
+  "tree": "Árvore",
   "trees": "Árvores",
   "the": "O",
   "forestGrows": "Floresta Cresce."

--- a/src/TreeTenantLeaderboard/App.svelte
+++ b/src/TreeTenantLeaderboard/App.svelte
@@ -72,7 +72,7 @@
 						<p class="user">{item.donorName}</p>
 						<p class="treeCount">
 							{getFormattedNumber(item.treeCount, locale)}
-							{' '}{language[locale].trees}
+							{' '}{item.treeCount === 1?language[locale].tree:language[locale].trees}
 						</p>
 					</li>
 				{/each}
@@ -87,7 +87,7 @@
 						<p class="user">{item.donorName}</p>
 						<p class="treeCount">
 							{getFormattedNumber(item.treeCount, locale)}
-							{' '}{language[locale].trees}
+							{' '}{item.treeCount === 1?language[locale].tree:language[locale].trees}
 						</p>
 					</div>
 				{/each}


### PR DESCRIPTION
Fixes https://planetfoundation.slack.com/archives/C02RPPHEQ9Y/p1697644461972539

Changes in this pull request:
- distinct between "tree" and "trees" for singular or plural number of trees