### PR TITLE
Update data sources for TreeMap and TreeProfile

### DIFF
--- a/src/TreeMap/App.svelte
+++ b/src/TreeMap/App.svelte
@@ -239,10 +239,10 @@
 								{community === 'true'
 									? localizedAbbreviatedNumber(
 											locale,
-											data.score.personal + data.score.received,
+											data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted,
 											1
 									  )
-									: localizedAbbreviatedNumber(locale, data.score.personal, 1)}
+									: localizedAbbreviatedNumber(locale, data.scores.treesDonated.personal + data.scores.treesPlanted, 1)}
 							</p>
 						</div>
 						{#if forestname}
@@ -267,9 +267,9 @@
 								>
 									{language[locale].treesPlanted}
 								</p>
-								{#if data.score.target != 0}
+								{#if data.scores.treesDonated.target != 0}
 									<p class="treecount">
-										{localizedAbbreviatedNumber(locale, data.score.target, 1)}
+										{localizedAbbreviatedNumber(locale, data.scores.treesDonated.target, 1)}
 									</p>
 									<p class="treecountLabel">{language[locale].target}</p>
 								{/if}
@@ -281,7 +281,7 @@
 							size * 2
 						}px;position:absolute;`}
 					>
-						{#if data.score.target > data.score.personal + data.score.received}
+						{#if data.scores.treesDonated.target > data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted}
 							<circle
 								cx={size}
 								cy={size}
@@ -293,11 +293,11 @@
 								stroke-dasharray={circumference}
 								stroke-dashoffset={circumference *
 									(1 -
-										(data.score.personal + data.score.received) /
-											data.score.target)}
+										(data.scores.treesDonated.personal + data.scores.treesDonated.received)  + data.scores.treesPlanted/
+											data.scores.treesDonated.target)}
 								fill="transparent"
 							/>
-						{:else if data.score.target < data.score.personal + data.score.received}
+						{:else if data.scores.treesDonated.target < data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted}
 							<circle
 								cx={size}
 								cy={size}
@@ -309,8 +309,8 @@
 								stroke-dasharray={circumference}
 								stroke-dashoffset={circumference *
 									(1 ==
-										(data.score.personal + data.score.received) /
-											data.score.target)}
+										(data.scores.treesDonated.personal + data.scores.treesDonated.received)  + data.scores.treesPlanted/
+											data.scores.treesDonated.target)}
 								fill="transparent"
 							/>
 						{/if}
@@ -367,7 +367,7 @@
 								<p class="infoText ">
 									{localizedAbbreviatedNumber(
 										locale,
-										Number(data.score.personal),
+										Number(data.scores.treesDonated.personal + data.scores.treesPlanted),
 										1
 									)}
 									{language[locale].treesPlantedBy}
@@ -375,7 +375,7 @@
 									{community === 'true'
 										? `${language[locale].and} ${localizedAbbreviatedNumber(
 												locale,
-												Number(data.score.received),
+												Number(data.scores.treesDonated.received),
 												1
 										  )} ${language[locale].treesPlantedByComm}`
 										: ''}

--- a/src/TreeMap/App.svelte
+++ b/src/TreeMap/App.svelte
@@ -110,10 +110,12 @@
 				fetchContributionsData.then((contributions) => {
 					let filteredContributions;
 					if (community === 'true') {
-						filteredContributions = contributions;
+						filteredContributions = contributions.filter((contrib) => {
+							return contrib.properties.plantDate !== null;
+						});
 					} else {
 						filteredContributions = contributions.filter((contrib) => {
-							return contrib.properties.type !== 'gift';
+							return contrib.properties.type !== 'gift' && contrib.properties.plantDate !== null;
 						});
 					}
 					const geojson = {

--- a/src/TreeProfile/App.svelte
+++ b/src/TreeProfile/App.svelte
@@ -100,10 +100,10 @@
 							{community === 'true'
 								? localizedAbbreviatedNumber(
 										locale,
-										data.score.personal + data.score.received,
+										data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted,
 										1
 								  )
-								: localizedAbbreviatedNumber(locale, data.score.personal, 1)}
+								: localizedAbbreviatedNumber(locale, data.scores.treesDonated.received + data.scores.treesPlanted, 1)}
 						</p>
 					</div>
 					{#if forestname}
@@ -122,9 +122,9 @@
 							<p class={`treecountLabel ${theme === 'dark' ? 'planted' : ''}`}>
 								{language[locale].treesPlanted}
 							</p>
-							{#if data.score.target != 0}
+							{#if data.scores.treesDonated.target != 0}
 								<p class="treecount">
-									{localizedAbbreviatedNumber(locale, data.score.target, 1)}
+									{localizedAbbreviatedNumber(locale, data.scores.treesDonated.target, 1)}
 								</p>
 								<p class="treecountLabel">{language[locale].target}</p>
 							{/if}
@@ -134,7 +134,7 @@
 				<svg
 					style={`width:${size * 2}px; height:${size * 2}px;position:absolute;`}
 				>
-					{#if data.score.target > data.score.personal + data.score.received}
+					{#if data.scores.treesDonated.target > data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted}
 						<circle
 							cx={size}
 							cy={size}
@@ -146,11 +146,11 @@
 							stroke-dasharray={circumference}
 							stroke-dashoffset={circumference *
 								(1 -
-									(data.score.personal + data.score.received) /
-										data.score.target)}
+									(data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted) /
+										data.scores.treesDonated.target)}
 							fill="transparent"
 						/>
-					{:else if data.score.target < data.score.personal + data.score.received}
+					{:else if data.scores.treesDonated.target < data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted}
 						<circle
 							cx={size}
 							cy={size}
@@ -162,8 +162,8 @@
 							stroke-dasharray={circumference}
 							stroke-dashoffset={circumference *
 								(1 ==
-									(data.score.personal + data.score.received) /
-										data.score.target)}
+									(data.scores.treesDonated.personal + data.scores.treesDonated.received + data.scores.treesPlanted) /
+										data.scores.treesDonated.target)}
 							fill="transparent"
 						/>
 					{/if}
@@ -246,7 +246,7 @@
 							<p class="infoText ">
 								{localizedAbbreviatedNumber(
 									locale,
-									Number(data.score.personal),
+									Number(data.scores.treesDonated.personal + data.scores.treesPlanted),
 									1
 								)}
 								{language[locale].treesPlantedBy}
@@ -254,7 +254,7 @@
 								{community === 'true'
 									? `${language[locale].and} ${localizedAbbreviatedNumber(
 											locale,
-											Number(data.score.received),
+											Number(data.scores.treesDonated.received),
 											1
 									  )} ${language[locale].treesPlantedByComm}`
 									: ''}


### PR DESCRIPTION
Fixes issue of incorrect treecounter score in TreeMap/TreeProfile, and non confirmed (i.e. plantDate = null) contributions displayed on TreeMap.

Changes in this pull request:
- Uses `scores` object instead of deprecated `score` object in /profile response
- Considers registeredTrees (`scores.treesPlanted`) in the displayed score on TreeMap/TreeProfile
- Filters out non confirmed contributions before displaying results on map

